### PR TITLE
fix(): updating the type of a & aaaa records field  to optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ map(object({
     resource_group_name = string
     zone_name           = string
     ttl                 = number
-    records             = list(string)
+    records             = optional(list(string))
     target_resource_id  = optional(string)
     tags                = optional(map(string), null)
   }))
@@ -104,7 +104,7 @@ map(object({
     resource_group_name = string
     zone_name           = string
     ttl                 = number
-    records             = list(string)
+    records             = optional(list(string))
     target_resource_id  = optional(string)
     tags                = optional(map(string), null)
   }))

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "a_records" {
     resource_group_name = string
     zone_name           = string
     ttl                 = number
-    records             = list(string)
+    records             = optional(list(string))
     target_resource_id  = optional(string)
     tags                = optional(map(string), null)
   }))
@@ -30,7 +30,7 @@ variable "aaaa_records" {
     resource_group_name = string
     zone_name           = string
     ttl                 = number
-    records             = list(string)
+    records             = optional(list(string))
     target_resource_id  = optional(string)
     tags                = optional(map(string), null)
   }))

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,15 @@ variable "a_records" {
   }))
   default     = {}
   description = "A map of objects where each object contains information to create a A record."
+  validation {
+    condition = alltrue([
+      for k, v in var.a_records : (
+        !(v.records != null && v.target_resource_id != null) &&
+        (v.records != null || v.target_resource_id != null)
+      )
+    ])
+    error_message = "Either 'records' or 'target_resource_id' must be specified for each A record in 'a_records' at a time."
+  }
 }
 
 variable "aaaa_records" {
@@ -36,6 +45,15 @@ variable "aaaa_records" {
   }))
   default     = {}
   description = "A map of objects where each object contains information to create a AAAA record."
+  validation {
+    condition = alltrue([
+      for k, v in var.aaaa_records : (
+        !(v.records != null && v.target_resource_id != null) &&
+        (v.records != null || v.target_resource_id != null)
+      )
+    ])
+    error_message = "Either 'records' or 'target_resource_id' must be specified for each AAAA record in 'aaaa_records' at a time."
+  }
 }
 
 variable "caa_records" {


### PR DESCRIPTION
To define aliases for A and AAAA records, the `record` field must be optional, allowing it to be omitted when necessary.